### PR TITLE
Add the ability to set API version via config

### DIFF
--- a/src/Insee.php
+++ b/src/Insee.php
@@ -35,7 +35,16 @@ class Insee
 
         // Fetch company information from Insee
         $client = new Client();
-        $result = $client->get('https://api.insee.fr/entreprises/sirene/V3/'.$type.'/'.$number, [
+
+        // Set API version
+        $api_version = config('insee.sirene_api_version', '');
+        if ($api_version) {
+            $url = 'https://api.insee.fr/entreprises/sirene/V'.$api_version;
+        } else {
+            $url = 'https://api.insee.fr/entreprises/sirene';
+        }
+
+        $result = $client->get($url.'/'.$type.'/'.$number, [
             'headers' => [
                 'Authorization' => 'Bearer '.$this->access_token(),
             ],

--- a/src/config/insee.php
+++ b/src/config/insee.php
@@ -13,6 +13,7 @@ return [
     |
     */
 
+    'sirene_api_version' => env('INSEE_SIRENE_API_VERSION'),
     'consumer_key'    => env('INSEE_CONSUMER_KEY'),
     'consumer_secret' => env('INSEE_CONSUMER_SECRET'),
 


### PR DESCRIPTION
SIRENE api endpoint `https://api.insee.fr/entreprises/sirene/V3` is no longer available.
Valid endpoints are now either one of the following :
 - https://api.insee.fr/entreprises/sirene/V3.11
 - https://api.insee.fr/entreprises/sirene/ 